### PR TITLE
fix(ci): Use --no-root for poetry install in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        poetry install --no-interaction --no-ansi
+        poetry install --no-interaction --no-ansi --no-root
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Updates the GitHub Actions workflow (`.github/workflows/ci.yml`) to use `poetry install --no-interaction --no-ansi --no-root`.

This prevents Poetry from trying to install the current project as a package, which was causing an error because the project is not currently configured as an installable package (e.g., missing `packages` definition in `pyproject.toml` for the `src` layout).

Using `--no-root` is appropriate for CI scenarios where tests are run directly against the source tree.